### PR TITLE
Add anti-spam middleware and stock overview tools

### DIFF
--- a/bot/handlers/admin/broadcast.py
+++ b/bot/handlers/admin/broadcast.py
@@ -1,13 +1,14 @@
 import asyncio
 from aiogram import Dispatcher
 from aiogram.types import Message, CallbackQuery
-from aiogram.utils.exceptions import BotBlocked
+from aiogram.utils.exceptions import BotBlocked, TelegramAPIError
 
 from bot.keyboards import back, close
 from bot.database.methods import check_role, get_all_users
 from bot.database.models import Permission
 from bot.misc import TgConfig
 from bot.logger_mesh import logger
+from bot.utils.safe_sender import safe_send_copy
 from bot.handlers.other import get_bot_user_ids
 
 
@@ -41,15 +42,18 @@ async def broadcast_messages(message: Message):
     max_users = 0
     for user_row in users:
         max_users += 1
-        target_id = user_row[0]
-        await asyncio.sleep(0.1)
+        target_id = int(user_row[0])
+        await asyncio.sleep(0.3)
         try:
-            await original_message.send_copy(
-                chat_id=int(target_id),
+            await safe_send_copy(
+                original_message,
+                target_id,
                 reply_markup=close(),
             )
         except BotBlocked:
-            pass
+            logger.info("Broadcast skipped for %s: bot blocked", target_id)
+        except TelegramAPIError as exc:
+            logger.warning("Failed to deliver broadcast to %s: %s", target_id, exc)
     TgConfig.STATE.pop(f'{sender_id}_message_id', None)
     await bot.edit_message_text(
         chat_id=message.chat.id,

--- a/bot/handlers/admin/main.py
+++ b/bot/handlers/admin/main.py
@@ -12,6 +12,7 @@ from bot.handlers.admin.shop_management_states import register_shop_management
 from bot.handlers.admin.user_management_states import register_user_management
 from bot.handlers.admin.assistant_management_states import register_assistant_management
 from bot.handlers.admin.view_stock import register_view_stock
+from bot.handlers.admin.stock_overview import register_stock_overview
 from bot.handlers.admin.purchases import register_purchases
 from bot.handlers.other import get_bot_user_ids
 
@@ -56,4 +57,5 @@ def register_admin_handlers(dp: Dispatcher) -> None:
     register_user_management(dp)
     register_assistant_management(dp)
     register_view_stock(dp)
+    register_stock_overview(dp)
     register_purchases(dp)

--- a/bot/handlers/admin/stock_overview.py
+++ b/bot/handlers/admin/stock_overview.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from aiogram import Dispatcher
+from aiogram.types import CallbackQuery
+
+from bot.database.methods import (
+    check_role,
+    get_all_category_names,
+    get_all_item_names,
+    get_all_subcategories,
+    check_value,
+    select_item_values_amount,
+)
+from bot.database.models import Permission
+from bot.handlers.other import get_bot_user_ids
+from bot.keyboards import back
+from bot.logger_mesh import logger
+from bot.utils import display_name
+from bot.utils.safe_sender import safe_send_message
+
+
+def _collect_category_lines(category: str, depth: int = 0) -> tuple[list[str], int]:
+    lines: list[str] = []
+    indent = "    " * depth
+    prefix = "📂" if depth == 0 else "📁"
+    lines.append(f"{indent}{prefix} {category}")
+
+    items = get_all_item_names(category)
+    total_items = 0
+    for item in items:
+        amount = '∞' if check_value(item) else select_item_values_amount(item)
+        lines.append(f"{indent}  • {display_name(item)} — {amount}")
+        total_items += 1
+
+    subcategories = get_all_subcategories(category)
+    for sub in subcategories:
+        sub_lines, sub_count = _collect_category_lines(sub, depth + 1)
+        lines.extend(sub_lines)
+        total_items += sub_count
+
+    return lines, total_items
+
+
+def _build_stock_overview() -> tuple[list[str], int, int]:
+    categories = get_all_category_names()
+    if not categories:
+        return ["📭 No categories or products found."], 0, 0
+
+    overview_lines: list[str] = []
+    total_items = 0
+    for index, category in enumerate(categories):
+        lines, item_count = _collect_category_lines(category)
+        overview_lines.extend(lines)
+        if index != len(categories) - 1:
+            overview_lines.append("")
+        total_items += item_count
+    return overview_lines, total_items, len(categories)
+
+
+def _chunk_lines(lines: Iterable[str], max_length: int = 3800) -> list[str]:
+    chunks: list[str] = []
+    current: list[str] = []
+    current_len = 0
+
+    for line in lines:
+        line = line.rstrip()
+        line_length = len(line) + 1  # account for newline
+        if current and current_len + line_length > max_length:
+            chunks.append("\n".join(current))
+            current = [line]
+            current_len = len(line)
+        else:
+            current.append(line)
+            current_len += line_length
+
+    if current:
+        chunks.append("\n".join(current))
+
+    return chunks
+
+
+async def stock_overview_callback_handler(call: CallbackQuery) -> None:
+    bot, user_id = await get_bot_user_ids(call)
+    role = check_role(user_id)
+    if not role & Permission.OWN:
+        await call.answer("Insufficient rights")
+        return
+
+    await call.answer()
+    lines, total_items, category_count = _build_stock_overview()
+    header = [
+        "📊 Stock overview",
+        f"📁 Categories: {category_count}",
+        f"🏷️ Products: {total_items}",
+        "",
+    ]
+    chunks = _chunk_lines(header + lines)
+
+    if not chunks:
+        chunks = ["📊 Stock overview\n\n📭 No categories or products found."]
+
+    first_chunk = chunks[0]
+    if not first_chunk.startswith("📊 Stock overview"):
+        first_chunk = "📊 Stock overview\n\n" + first_chunk
+
+    await bot.edit_message_text(
+        first_chunk,
+        chat_id=call.message.chat.id,
+        message_id=call.message.message_id,
+        reply_markup=back("console"),
+    )
+
+    for chunk in chunks[1:]:
+        await safe_send_message(call.message, chunk)
+
+    logger.info("User %s viewed stock overview", user_id)
+
+
+def register_stock_overview(dp: Dispatcher) -> None:
+    dp.register_callback_query_handler(
+        stock_overview_callback_handler,
+        lambda c: c.data == "view_stock_overview",
+        state="*",
+    )

--- a/bot/handlers/admin/view_stock.py
+++ b/bot/handlers/admin/view_stock.py
@@ -45,6 +45,7 @@ async def view_stock_callback_handler(call: CallbackQuery):
             message_id=call.message.message_id,
             reply_markup=stock_categories_list(user_id, categories, None),
         )
+        await call.answer()
         return
     await call.answer('Insufficient rights')
 
@@ -336,7 +337,7 @@ async def stock_price_input_handler(message: Message):
 
 def register_view_stock(dp: Dispatcher) -> None:
     dp.register_callback_query_handler(
-        view_stock_callback_handler, lambda c: c.data == 'view_stock'
+        view_stock_callback_handler, lambda c: c.data == 'manage_stock'
     )
     dp.register_callback_query_handler(
         view_stock_category_handler,

--- a/bot/keyboards/inline.py
+++ b/bot/keyboards/inline.py
@@ -6,6 +6,7 @@ from bot.database.methods import (
     get_category_parent,
     select_item_values_amount,
     has_used_promo_for_item,
+    check_value,
 )
 from bot.misc import TgConfig
 from bot.utils import display_name
@@ -150,8 +151,13 @@ def console(role: int) -> InlineKeyboardMarkup:
          InlineKeyboardButton('📢 Pranešimų siuntimas', callback_data='send_message')],
     ]
     if role & Permission.OWN:
-        inline_keyboard.insert(0, [InlineKeyboardButton('🛠 Assign assistants', callback_data='assistant_management'),
-                                   InlineKeyboardButton('📦 View Stock', callback_data='view_stock')])
+        inline_keyboard.insert(0, [
+            InlineKeyboardButton('🛠 Assign assistants', callback_data='assistant_management'),
+            InlineKeyboardButton('🧰 Manage Stock', callback_data='manage_stock')
+        ])
+        inline_keyboard.insert(1, [
+            InlineKeyboardButton('📊 View Stock', callback_data='view_stock_overview')
+        ])
     inline_keyboard.append([InlineKeyboardButton('❓ Help', callback_data='admin_help')])
     inline_keyboard.append([InlineKeyboardButton('🔙 Back to menu', callback_data='back_to_menu')])
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
@@ -436,7 +442,7 @@ def stock_goods_list(user_id: int, list_items: list[str], category_name: str) ->
     _get_category_token(cache, category_name)
     markup = InlineKeyboardMarkup()
     for name in list_items:
-        amount = select_item_values_amount(name)
+        amount = '∞' if check_value(name) else select_item_values_amount(name)
         item_token = _get_item_token(cache, name)
         markup.add(InlineKeyboardButton(
             text=f'{display_name(name)} ({amount})',

--- a/bot/localization.py
+++ b/bot/localization.py
@@ -24,7 +24,8 @@ LANGUAGES = {
         'admin_help_info': (
             'Admin panel functions:\n'
             '🛠 Assign assistants – manage assistant accounts.\n'
-            '📦 View Stock – browse and delete available product stock.\n'
+            '🧰 Manage Stock – update prices and stock entries.\n'
+            '📊 View Stock – overview of categories and item quantities.\n'
             '🏪 Parduotuvės valdymas – manage shop categories and items.\n'
             '👥 Vartotojų valdymas – manage user balances and roles.\n'
             '📢 Pranešimų siuntimas – send messages to all users.'
@@ -130,7 +131,8 @@ LANGUAGES = {
         'admin_help_info': (
             'Функции админ-панели:\n'
             '🛠 Назначить ассистентов – управление помощниками.\n'
-            '📦 Просмотр склада – список товаров и удаление остатков.\n'
+            '🧰 Управление складом – обновление цен и остатков товаров.\n'
+            '📊 Просмотр склада – обзор категорий и количества товаров.\n'
             '🏪 Parduotuvės valdymas – управление магазином.\n'
             '👥 Vartotojų valdymas – управление пользователями.\n'
             '📢 Pranešimų siuntimas – рассылка сообщений.'

--- a/bot/main.py
+++ b/bot/main.py
@@ -7,6 +7,7 @@ from bot.misc import EnvKeys
 from bot.handlers import register_all_handlers
 from bot.database.models import register_models
 from bot.logger_mesh import logger, file_handler
+from bot.middlewares import setup_middlewares
 
 logger.addHandler(file_handler)
 
@@ -33,4 +34,5 @@ async def __on_start_up(dp: Dispatcher) -> None:
 def start_bot():
     bot = Bot(token=EnvKeys.TOKEN, parse_mode='HTML')
     dp = Dispatcher(bot, storage=MemoryStorage())
+    setup_middlewares(dp)
     executor.start_polling(dp, skip_updates=True, on_startup=__on_start_up)

--- a/bot/middlewares/__init__.py
+++ b/bot/middlewares/__init__.py
@@ -1,0 +1,8 @@
+from aiogram import Dispatcher
+
+from .antispam import setup_antispam
+
+
+def setup_middlewares(dp: Dispatcher) -> None:
+    """Register all middlewares used by the bot."""
+    setup_antispam(dp)

--- a/bot/middlewares/antispam.py
+++ b/bot/middlewares/antispam.py
@@ -1,0 +1,108 @@
+import asyncio
+
+from aiogram import types
+from aiogram.dispatcher import DEFAULT_RATE_LIMIT, Dispatcher
+from aiogram.dispatcher.handler import CancelHandler, current_handler
+from aiogram.dispatcher.middlewares import BaseMiddleware
+from aiogram.utils.exceptions import Throttled
+
+from bot.logger_mesh import logger
+
+
+class AntiSpamMiddleware(BaseMiddleware):
+    """Simple anti-spam middleware that throttles user actions."""
+
+    def __init__(
+        self,
+        message_rate: float = 1.0,
+        callback_rate: float = 0.7,
+        warn_after: int = 1,
+        cooldown_multiplier: float = 1.5,
+    ) -> None:
+        super().__init__()
+        self.message_rate = message_rate or DEFAULT_RATE_LIMIT
+        self.callback_rate = callback_rate or DEFAULT_RATE_LIMIT
+        self.warn_after = max(warn_after, 0)
+        self.cooldown_multiplier = max(cooldown_multiplier, 1.0)
+        self._prefix = "antispam"
+
+    async def on_process_message(self, message: types.Message, data: dict) -> None:
+        await self._throttle(target=message, event_type="message")
+
+    async def on_process_callback_query(
+        self, callback_query: types.CallbackQuery, data: dict
+    ) -> None:
+        await self._throttle(target=callback_query, event_type="callback")
+
+    async def _throttle(
+        self,
+        target: types.Message | types.CallbackQuery,
+        event_type: str,
+    ) -> None:
+        dp = Dispatcher.get_current()
+        handler = current_handler.get()
+
+        if handler:
+            limit = getattr(
+                handler,
+                "throttling_rate_limit",
+                self.callback_rate if event_type == "callback" else self.message_rate,
+            )
+            key = getattr(
+                handler,
+                "throttling_key",
+                f"{self._prefix}:{event_type}:{handler.__name__}:{target.from_user.id}",
+            )
+        else:
+            limit = self.callback_rate if event_type == "callback" else self.message_rate
+            key = f"{self._prefix}:{event_type}:{target.from_user.id}"
+
+        try:
+            await dp.throttle(key, rate=limit)
+        except Throttled as throttled:
+            await self._handle_throttled(target, throttled, event_type)
+            raise CancelHandler()
+
+    async def _handle_throttled(
+        self,
+        target: types.Message | types.CallbackQuery,
+        throttled: Throttled,
+        event_type: str,
+    ) -> None:
+        user_id = target.from_user.id
+        wait_time = throttled.rate * self.cooldown_multiplier
+        warn_user = throttled.exceeded_count <= self.warn_after + 1
+
+        if isinstance(target, types.CallbackQuery):
+            try:
+                if warn_user:
+                    await target.answer(
+                        "⚠️ You're interacting too quickly. Please slow down.",
+                        show_alert=False,
+                    )
+                else:
+                    await target.answer(
+                        "⏳ Too many requests. Try again in a few seconds.",
+                        show_alert=True,
+                    )
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.debug("Failed to answer throttled callback for %s: %s", user_id, exc)
+        else:
+            message: types.Message = target
+            try:
+                if warn_user:
+                    await message.reply(
+                        "⚠️ Slow down! Please wait a moment before sending another command.",
+                    )
+                else:
+                    await message.reply(
+                        f"⏳ You're sending messages too quickly. Try again in {wait_time:.1f}s.",
+                    )
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.debug("Failed to notify throttled user %s: %s", user_id, exc)
+
+        await asyncio.sleep(wait_time)
+
+
+def setup_antispam(dp: Dispatcher) -> None:
+    dp.middleware.setup(AntiSpamMiddleware())

--- a/bot/utils/safe_sender.py
+++ b/bot/utils/safe_sender.py
@@ -1,0 +1,44 @@
+import asyncio
+from typing import Any, Awaitable, Callable
+
+from aiogram.types import Message
+from aiogram.utils.exceptions import NetworkError, RetryAfter, TelegramAPIError
+
+from bot.logger_mesh import logger
+
+
+async def _safe_telegram_call(call: Callable[[], Awaitable[Any]], *, context: str) -> Any | None:
+    """Execute a Telegram API call with retry on flood-related errors."""
+    attempt = 0
+    while True:
+        try:
+            return await call()
+        except RetryAfter as exc:
+            delay = getattr(exc, "timeout", getattr(exc, "retry_after", 1)) + 0.5
+            attempt += 1
+            logger.warning("RetryAfter while %s. Sleeping %.1fs (attempt %s)", context, delay, attempt)
+            await asyncio.sleep(delay)
+        except NetworkError as exc:
+            attempt += 1
+            delay = min(5, 0.5 * attempt)
+            logger.warning("Network error while %s: %s. Retrying in %.1fs", context, exc, delay)
+            await asyncio.sleep(delay)
+        except TelegramAPIError as exc:
+            logger.error("Telegram API error while %s: %s", context, exc)
+            return None
+
+
+def safe_send_message(message: Message, text: str, **kwargs) -> Awaitable[Any | None]:
+    """Safely send a new message reusing the bot from a message object."""
+    return _safe_telegram_call(
+        lambda: message.bot.send_message(chat_id=message.chat.id, text=text, **kwargs),
+        context="sending message",
+    )
+
+
+def safe_send_copy(original: Message, chat_id: int, **kwargs) -> Awaitable[Any | None]:
+    """Safely copy a message to another chat."""
+    return _safe_telegram_call(
+        lambda: original.send_copy(chat_id=chat_id, **kwargs),
+        context=f"copying message to {chat_id}",
+    )


### PR DESCRIPTION
## Summary
- add an anti-spam middleware and safe send helpers to throttle user actions and retry Telegram API calls
- slow down broadcast delivery to reduce flood bans and surface logging for blocked recipients
- rename the admin stock management entry, show item stock counts, and add a read-only stock overview callback

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68d83224c3548332806d41d6004a8d2b